### PR TITLE
Remove unnecessary padding from main content on mobile (fixes #36)

### DIFF
--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -1,6 +1,6 @@
 .main-content {
   font-size: 1rem;
-  padding: 50px 0;
+  padding: 0px 0;
   h1,
   h2,
   h3,
@@ -26,8 +26,6 @@
     margin: 0 0 $spacing-paragraph;
   }
   @media (min-width: $bp-tablet) {
-    padding: 0px 0;
-
   .section-headline {
     border-bottom: none;
   }


### PR DESCRIPTION
The main content had extra padding only on small width, that doesn't sound necessary.
so removed the branch and made the padding on large width default