### PR TITLE
Use Media queries for dark/light mode

### DIFF
--- a/_sass/_a11y.scss
+++ b/_sass/_a11y.scss
@@ -21,6 +21,7 @@
 // Offset of 0 interacts better with menu separator.
 .page-menu :focus {
   outline-offset: 0;
+  outline-color: var(--color-nav);
 }
 
 .featurelist__item__tag,

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -8,17 +8,17 @@
       h2 {
         text-decoration: none;
         padding: 5px 10px 5px 10px;
-        background-color: $color-bg;
-        color: $color-primary;
-        border-bottom: 1px solid $color-primary;
+        background-color: var(--color-bg);
+        color: var(--color-primary);
+        border-bottom: 1px solid var(--color-primary);
         &:hover {
-          background-color: $color-primary;
-          color: $color-bg;
+          background-color: var(--color-primary);
+          color: var(--color-bg);
           border-bottom: none;
         }
       }
       @media (min-width: $bp-tablet) {
-        border-bottom: 1px solid $color-primary;
+        border-bottom: 1px solid var(--color-primary);
         display: inline-block;
       }
     }

--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -7,7 +7,7 @@
   h4,
   h5,
   h6 {
-    color: $color-text;
+    color: var(--color-text);
     font-weight: $font-weight-semi-bold;
   }
   h3 {
@@ -40,7 +40,7 @@
 }
 
 a {
-  color: $color-link;
+  color: var(--color-link);
   font-weight: $font-weight-semi-bold;
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -9,8 +9,8 @@ html {
 }
 
 body {
-  background: $color-bg;
-  color: $color-text;
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: sans-serif;
   font-size: 16px;
   font-weight: $font-weight-regular;

--- a/_sass/_logo-box.scss
+++ b/_sass/_logo-box.scss
@@ -26,7 +26,7 @@
   }
 }
 .spidermonkey-logo {
-  fill: $color-logo-full;
+  fill: var(--color-logo-full);
   fill-opacity:1;
   stroke:none
 }
@@ -34,12 +34,12 @@
 .spidermonkey-text {
   font-size:17.6389px;
   font-family: ZillaSlab-regular;
-  fill: $color-logo-full;
+  fill: var(--color-logo-full);
 }
 
 .spidermonkey-circle {
-  fill: $color-logo-1;
+  fill: var(--color-logo-1);
 }
 .spidermonkey-small {
-  fill: $color-logo-2;
+  fill: var(--color-logo-2);
 }

--- a/_sass/_page-footer.scss
+++ b/_sass/_page-footer.scss
@@ -18,14 +18,14 @@
 }
 
 .page-footer {
-  color: $color-dim-gray;
+  color: var(--color-dim-gray);
   font-size: 12px;
   min-height: 100px;
   width: 100%;
 }
 
 .page-footer h3 {
-  border-bottom: 1px solid mix($color-bg, $color-dim-gray, $weight: 80%);
+  border-bottom: 1px solid var(--color-dim-bg);
   margin-bottom: 1.25rem;
   margin-top: 1.25rem;
   padding-bottom: 1em;
@@ -37,7 +37,7 @@
   }
 
   .page-footer .synopsis .g-col-3:not(:last-child) {
-    border-right: solid 1px mix($color-bg, $color-dim-gray, $weight: 80%);
+    border-right: solid 1px var(--color-dim-bg);
     padding-right: $grid-gutter;
   }
 
@@ -47,7 +47,7 @@
 }
 
 .page-footer a {
-  color: $color-link;
+  color: var(--color-link);
   font-weight: $font-weight-regular;
   line-height: 24px;
   text-decoration: underline;
@@ -59,13 +59,13 @@
   }
 
   .icon path {
-    fill: $color-dim-gray;
+    fill: var(--color-dim-gray);
   }
 
   &:active .icon path,
   &:focus .icon path,
   &:hover .icon path {
-    fill: $color-link;
+    fill: var(--color-link);
   }
 
   span {
@@ -95,7 +95,7 @@
 }
 
 .page-footer .grid-container {
-  border-top: solid 1px mix($color-bg, $color-dim-gray, $weight: 80%);
+  border-top: solid 1px var(--color-dim-bg);
   margin: 0 auto;
   overflow: auto;
   padding: $grid-gutter 0;

--- a/_sass/_page-menu.scss
+++ b/_sass/_page-menu.scss
@@ -33,7 +33,7 @@ $trans-timing: 600ms;
   $mt: 73.6px;
   margin-top: $mt;
   .menu {
-    background: $color-submenu-bg;
+    background: var(--color-submenu-bg);
     display: block;
     left: 0;
     list-style-type: none;
@@ -59,10 +59,10 @@ $trans-timing: 600ms;
       }
     }
     &-item:not(:last-child) {
-      border-right: 1px solid $color-primary;
+      border-right: 1px solid var(--color-primary);
     }
     &-link {
-      color: $color-nav;
+      color: var(--color-nav);
       cursor: pointer;
       display: block;
       flex: none;
@@ -82,8 +82,8 @@ $trans-timing: 600ms;
       &:hover,
       &:focus,
       &.active {
-        color: $color-bg;
-        background-color: $color-primary;
+        color: var(--color-bg);
+        background-color: var(--color-primary);
         font-weight: $font-weight-semi-bold;
         text-decoration: none;
       }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,35 +1,38 @@
 // Colors
-$color-lightmode-primary: orange;
-$color-lightmode-link: orange;
-$color-lightmode-text: #000;
-$color-lightmode-nav: #444;
-$color-lightmode-spacer: #eee;
-$color-lightmode-submenu-bg: white;
-$color-lightmode-bg: white;
-$color-lightmode-dim-gray: #696969;
 
-$color-darkmode-primary: #ffc752;
-$color-darkmode-link: #ffc752;
-$color-darkmode-text: #ffc752;
-$color-darkmode-nav: #444;
-$color-darkmode-spacer: #eee;
-$color-darkmode-submenu-bg: white;
-$color-darkmode-bg: #1b143b;
-$color-darkmode-dim-gray: #696969;
+// Dark mode.
+:root {
+  --color-primary: #ffc752;
+  --color-text: #ffc752;
+  --color-link: #ffc752;
+  --color-nav: #444;
+  --color-spacer: #eee;
+  --color-submenu-bg: #1b143b;
+  --color-bg: #1b143b;
+  --color-dim-gray: #696969;
+  --color-darkmode-dim-bg: #2b2544; // = 0.8 * --color-darkmode-bg + 0.2 * --color-darkmode-dim-gray
+  --color-logo-full: #ffc752;
+  --color-logo-1: #1b143b;
+  --color-logo-2: #ffc752;
+}
 
-$color-primary: #ffc752;
-$color-text: #ffc752;
-$color-link: #ffc752;
-$color-text: #ffc752;
-$color-nav: #ffc752;
-$color-spacer: #eee;
-$color-submenu-bg: #1b143b;
-$color-bg: #1b143b;
-$color-dim-gray: #696969;
-
-$color-logo-full: #ffc752;
-$color-logo-1: #1b143b;
-$color-logo-2: #ffc752;
+// Light mode
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-primary: orange;
+    --color-link: orange;
+    --color-text: #000;
+    --color-nav: #444;
+    --color-spacer: #eee;
+    --color-submenu-bg: white;
+    --color-bg: white;
+    --color-dim-gray: #696969;
+    --color-dim-bg: #e1e1e1; // = 0.8 * --color-bg + 0.2 * --color-dim-gray
+    --color-logo-full: #ffc752;
+    --color-logo-1: #1b143b;
+    --color-logo-2: #ffc752;
+  }
+}
 
 // Font weights
 $font-weight-light: 300;


### PR DESCRIPTION
This patch changes the the SASS variables for handling colors by CSS variables, and should toggle light/dark mode based on the preferences set in the browser.

However, testing on Firefox nightly does not seems to use the dark mode set for Firefox UI.

edit: This is working, I just have a devtools addition which let me switch between dark/light mode, but is by default using light mode instead of the browser setting.
