### PR TITLE
Split index.mardown in multiple files.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,6 @@ header_pages:
 
 sass:
   style: compressed
+
+collections:
+  - home

--- a/_home/building_and_contributing.markdown
+++ b/_home/building_and_contributing.markdown
@@ -1,0 +1,9 @@
+---
+title: Building and Contributing
+order: 4
+---
+
+* [Build Documentation](https://firefox-source-docs.mozilla.org/js/build.html)
+* [Running tests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Running_Automated_JavaScript_Tests)
+* [File a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=JavaScript%20Engine)
+* [Good first bugs](https://codetribute.mozilla.org/projects/jseng)

--- a/_home/embedding_spidermonkey.markdown
+++ b/_home/embedding_spidermonkey.markdown
@@ -1,0 +1,6 @@
+---
+title: Embedding SpiderMonkey
+order: 5
+---
+
+* [Examples and Documentation](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples)

--- a/_home/find_us.markdown
+++ b/_home/find_us.markdown
@@ -1,0 +1,14 @@
+---
+title: Where to find us
+order: 6
+---
+
+* Matrix chat: [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org)
+* Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
+* Twitter: [spidermonkeyjs](https://www.twitter.com/spidermonkeyjs)
+
+NOTE: The mailing lists are being phased out. You can now connect to our
+Discourse category by email for a similar experience. The archives should
+continue to remain available at:
+* [mozilla.dev.tech.js-engine](https://groups.google.com/g/mozilla.dev.tech.js-engine)
+* [mozilla.dev.tech.js-engine.internals](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)

--- a/_home/spidermonkey_internals.markdown
+++ b/_home/spidermonkey_internals.markdown
@@ -1,0 +1,16 @@
+---
+title: SpiderMonkey Internals
+order: 3
+---
+
+### Understanding the engine
+* [Overview of SpiderMonkey](https://firefox-source-docs.mozilla.org/js/index.html)
+* [Browse the code](https://searchfox.org/mozilla-central/source/js/src)
+* [SMDOC Source Comments](https://searchfox.org/mozilla-central/search?q=[SMDOC]&path=js%2F)
+
+### In-depth Articles:
+* [Warp: Improved JS Performance](https://hacks.mozilla.org/2020/11/warp-improved-js-performance-in-firefox-83/)
+* [Compiler Compiler: A Twitch series](https://hacks.mozilla.org/2020/06/compiler-compiler-working-on-a-javascript-engine/)
+* [A New RegExp Engine](https://hacks.mozilla.org/2020/06/a-new-regexp-engine-in-spidermonkey/)
+* [Future-proofing the Debugger Implementation](https://hacks.mozilla.org/2020/03/future-proofing-firefoxs-javascript-debugger-implementation/)
+* [The Baseline Interpreter](https://hacks.mozilla.org/2019/08/the-baseline-interpreter-a-faster-js-interpreter-in-firefox-70/)

--- a/_home/what_s_net.markdown
+++ b/_home/what_s_net.markdown
@@ -1,0 +1,6 @@
+---
+title: What's New
+order: 2
+---
+
+* [SpiderMonkey Blog](./blog)

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+
+{{ content }}
+
+{% assign sections = site.home | sort: 'order' %}
+{% for section in sections %}
+<h2>{{ section.title }}</h2>
+<hr>
+{{ section.content }}
+{% endfor %}

--- a/index.markdown
+++ b/index.markdown
@@ -1,56 +1,11 @@
 ---
-layout: default
+layout: home
 title: Home
 ---
 
 # Welcome!
+
 SpiderMonkey is Mozilla's JavaScript and WebAssembly Engine, used in
 [Firefox](https://www.mozilla.org/en-US/firefox/), [Servo](https://servo.org/)
 and [various](https://discourse.mozilla.org/t/survey-where-are-you-embedding-spidermonkey/77988)
 other projects. It is written in C++ and Rust.
-
-## What's New
-
----
-* [SpiderMonkey Blog](./blog)
-
-## SpiderMonkey Internals
-
----
-### Understanding the engine
-* [Overview of SpiderMonkey](https://firefox-source-docs.mozilla.org/js/index.html)
-* [Browse the code](https://searchfox.org/mozilla-central/source/js/src)
-* [SMDOC Source Comments](https://searchfox.org/mozilla-central/search?q=[SMDOC]&path=js%2F)
-
-### In-depth Articles:
-* [Warp: Improved JS Performance](https://hacks.mozilla.org/2020/11/warp-improved-js-performance-in-firefox-83/)
-* [Compiler Compiler: A Twitch series](https://hacks.mozilla.org/2020/06/compiler-compiler-working-on-a-javascript-engine/)
-* [A New RegExp Engine](https://hacks.mozilla.org/2020/06/a-new-regexp-engine-in-spidermonkey/)
-* [Future-proofing the Debugger Implementation](https://hacks.mozilla.org/2020/03/future-proofing-firefoxs-javascript-debugger-implementation/)
-* [The Baseline Interpreter](https://hacks.mozilla.org/2019/08/the-baseline-interpreter-a-faster-js-interpreter-in-firefox-70/)
-
-## Building and Contributing
-
----
-* [Build Documentation](https://firefox-source-docs.mozilla.org/js/build.html)
-* [Running tests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Running_Automated_JavaScript_Tests)
-* [File a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=JavaScript%20Engine)
-* [Good first bugs](https://codetribute.mozilla.org/projects/jseng)
-
-## Embedding SpiderMonkey
-
----
-* [Examples and Documentation](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples)
-
-## Where to find us
-
----
-* Matrix chat: [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org)
-* Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
-* Twitter: [spidermonkeyjs](https://www.twitter.com/spidermonkeyjs)
-
-NOTE: The mailing lists are being phased out. You can now connect to our
-Discourse category by email for a similar experience. The archives should
-continue to remain available at:
-* [mozilla.dev.tech.js-engine](https://groups.google.com/g/mozilla.dev.tech.js-engine)
-* [mozilla.dev.tech.js-engine.internals](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)


### PR DESCRIPTION
This patch replaces the top-level `index.markdown` by multiples files in `_home`, such that later we can better style the sub-sections of the index page.

It creates a new layout `home` which is in charge or rendering the `index.markdown` file and include the sub-sections as well.

