### PR TITLE
Move former mailing lists to embedder section

### DIFF
--- a/_home/embedding_spidermonkey.markdown
+++ b/_home/embedding_spidermonkey.markdown
@@ -4,3 +4,5 @@ order: 5
 ---
 
 * [Examples and Documentation](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples)
+* [mozilla.dev.tech.js-engine (ARCHIVED)](https://groups.google.com/g/mozilla.dev.tech.js-engine)
+* [mozilla.dev.tech.js-engine.internals (ARCHIVED)](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)

--- a/_home/find_us.markdown
+++ b/_home/find_us.markdown
@@ -6,9 +6,3 @@ order: 6
 * Matrix chat: [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org)
 * Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
 * Twitter: [spidermonkeyjs](https://www.twitter.com/spidermonkeyjs)
-
-NOTE: The mailing lists are being phased out. You can now connect to our
-Discourse category by email for a similar experience. The archives should
-continue to remain available at:
-* [mozilla.dev.tech.js-engine](https://groups.google.com/g/mozilla.dev.tech.js-engine)
-* [mozilla.dev.tech.js-engine.internals](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)

--- a/contribute.markdown
+++ b/contribute.markdown
@@ -27,12 +27,6 @@ on Matrix or discourse. We also maintain a twitter, where you will find updates 
 * Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
 * Twitter: [spidermonkeyjs](https://www.twitter.com/spidermonkeyjs)
 
-NOTE: The mailing lists are being phased out. You can now connect to our
-Discourse category by email for a similar experience. The archives should
-continue to remain available at:
-* [mozilla.dev.tech.js-engine](https://groups.google.com/g/mozilla.dev.tech.js-engine)
-* [mozilla.dev.tech.js-engine.internals](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)
-
 ## Community Participation Guidelines
 
 ---

--- a/docs.markdown
+++ b/docs.markdown
@@ -26,6 +26,8 @@ permalink: /docs/
 
 ---
 * [Examples and Documentation](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples)
+* [mozilla.dev.tech.js-engine (ARCHIVED)](https://groups.google.com/g/mozilla.dev.tech.js-engine)
+* [mozilla.dev.tech.js-engine.internals (ARCHIVED)](https://groups.google.com/g/mozilla.dev.tech.js-engine.internals)
 
 # The Monkeys
 


### PR DESCRIPTION
This historical archive seems most to be most useful for embedders since
there used to be more embedder discussions and many people are still on
older versions.