### PR TITLE
Fix Skip to content link (fixes #84)

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -2,7 +2,7 @@
 {%- assign page_paths = site.header_pages | default: default_paths -%}
 
 <a href="#content" class="skip-menu">
-  skip menu
+  skip to content
 </a>
 <a class="menu-toggle" tabindex="-1">
   <span class="menu-toggle-text">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
   </head>
   <body class="no-js">
     {% include header.html %}
-    <main class="container">
+    <main id="content" class="container">
     <section class="main-content">
     <div class="g-row">
       <div class="g-col-9">


### PR DESCRIPTION
In tc39.es, there's h1 element with `id="content"`, but we don't have it.  instead, added `id="content"` to `main` element,
and also change the link text to align with tc39.es that uses "skip to content"