### PR TITLE
Include future-dated posts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,3 @@ title: "My Title"
 date: 2021-05-03 09:30:00 +0700
 ---
 ```
-
-- **Important**: Note if that date is in the future, by default Jekyll will not include the post.

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ defaults:
 baseurl: "/"
 url: "https://spidermonkey.dev"
 permalink: /blog/:year/:month/:day/:title.html
+future: true
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Include future-dated posts to avoid confusion.