### PR TITLE
Fix links to removed MDN pages

### DIFF
--- a/_home/building_and_contributing.markdown
+++ b/_home/building_and_contributing.markdown
@@ -4,6 +4,6 @@ order: 4
 ---
 
 * [Build Documentation](https://firefox-source-docs.mozilla.org/js/build.html)
-* [Running tests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Running_Automated_JavaScript_Tests)
+* [Running tests](https://firefox-source-docs.mozilla.org/js/test.html)
 * [File a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=JavaScript%20Engine)
 * [Good first bugs](https://codetribute.mozilla.org/projects/jseng)

--- a/contribute.markdown
+++ b/contribute.markdown
@@ -15,7 +15,7 @@ on Matrix or discourse. We also maintain a twitter, where you will find updates 
 ---
 
 * [Build Documentation](https://firefox-source-docs.mozilla.org/js/build.html)
-* [Running tests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Running_Automated_JavaScript_Tests)
+* [Running tests](https://firefox-source-docs.mozilla.org/js/test.html)
 * [File a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=JavaScript%20Engine)
 * [Good first bugs](https://codetribute.mozilla.org/projects/jseng)
 

--- a/index.markdown
+++ b/index.markdown
@@ -8,4 +8,4 @@ title: Home
 SpiderMonkey is Mozilla's JavaScript and WebAssembly Engine, used in
 [Firefox](https://www.mozilla.org/en-US/firefox/), [Servo](https://servo.org/)
 and [various](https://discourse.mozilla.org/t/survey-where-are-you-embedding-spidermonkey/77988)
-other projects. It is written in C++, Rust and JavaScript. You can embed it into [C++](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples) and [Rust](https://github.com/servo/rust-mozjs) projects, and it can be run as a [stand-alone shell](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell).
+other projects. It is written in C++, Rust and JavaScript. You can embed it into [C++](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples) and [Rust](https://github.com/servo/rust-mozjs) projects, and it can be run as a stand-alone shell.


### PR DESCRIPTION
SpiderMonkey docs were removed from MDN. The Running Automated JavaScript tests page was moved, but other linked pages seem to not have been. Also, I didn't want to change blog posts, but the Firefox 73 newsletter links the bytecode documentation, which was also removed. Notably, that page was autogenerated by https://searchfox.org/mozilla-central/source/js/src/vm/make_opcode_doc.py, which still exists.