### PR TITLE
Fix hr width in areweesmifiedyet

### DIFF
--- a/areweesmifiedyet/css/page.css
+++ b/areweesmifiedyet/css/page.css
@@ -108,7 +108,7 @@ h2 + hr {
   margin: 0 10px;
   border: none;
   border-bottom: 1px solid var(--color-primary);
-  width: 100%;
+  width: calc(100% - 20px);
 }
 
 #logo {


### PR DESCRIPTION
The width of `hr` should take the horizontal margin into account.
This fixes the unnecessary horizontal scrollbar in the page.