### PR TITLE
fix: correct moment.js to lodash.js in import-maps post

### DIFF
--- a/_posts/2023-02-23-javascript-import-maps-part-1-introduction.md
+++ b/_posts/2023-02-23-javascript-import-maps-part-1-introduction.md
@@ -166,7 +166,7 @@ the same name so your websites will load faster. But what if we update our
 module? In this case, we would have to do “cache busting”. That is, we rename
 the file we are loading. The name will be appended with the hash of the file’s
 content. In the above example, `lodash.js` could become `lodash-1234abcd.js`,
-where the `"1234abcd"` is the hash of the content of moment.js.
+where the `"1234abcd"` is the hash of the content of lodash.js.
 
 
 ```


### PR DESCRIPTION
Hey, great article and explanation for `import-maps`. I think when you are referring for the example for content hash.
```
where the `"1234abcd"` is the hash of the content of moment.js
```

The examples are actually showing `lodash.js`. So, it's kinda confused at the beginning why `moment.js` is being hashed to `lodash.js` file
