### PR TITLE
Add nodes and descriptions to tech tree's stencilNav node (fixes #138)

### DIFF
--- a/tech_tree/diagram.mmd
+++ b/tech_tree/diagram.mmd
@@ -120,8 +120,7 @@ flowchart LR
     offThreadNeckoAPI --> adaptableJSLoading
 
     root --> contextFreeParsing["JSContext Free Parsing"]
-    %% This is a "nice to have" dependency, but the renderer doesn't support dashed lines yet, so leave it out for now
-    %%contextFreeParsing -.-> stencilNav
+    contextFreeParsing -.-> stencilNav
     contextFreeParsing --> adaptableJSLoading
     contextFreeParsing --> streamingParsing[/"Streaming Parsing"/]
     click streamingParsing "#streamingParsing"
@@ -172,7 +171,7 @@ flowchart LR
 
     selfHostedCacheIROps --> lowerOverheadSelfHostedCacheIR
 
-    generatorBytecodeTransforms --> resumeInWarp
+    generatorBytecodeTransforms -.-> resumeInWarp
 
 
     %%subgraph ionImprovements [Ion Improvements]

--- a/tech_tree/diagram.mmd
+++ b/tech_tree/diagram.mmd
@@ -44,9 +44,9 @@ flowchart LR
     tossBytecode --> optimizedBytecode["Optimized Bytecode Emission"]
     click tossBytecode href "#tossBytecode"
 
-    progressiveStencil[/"Progressive Stencil"/]
-    click progressiveStencil "#progressiveStencil"
-    nonGCScopes --> progressiveStencil
+    runFromStencil[/"Run From Stencil"/]
+    click runFromStencil "#runFromStencil"
+    nonGCScopes --> runFromStencil
 
     root --> immutableFlag["Immutable Object Detection at Parse Time"] --> optimizedImmutableLookups[/"Optimized Immutable Lookups"/]
     click immutableFlag href "#immutableFlag"
@@ -105,21 +105,24 @@ flowchart LR
 
     stencilNav[/"In-Memory Stencil Caching (stencil-nav)"/]
     click stencilNav "#stencilNav"
-    stencilNav --> decoupledCaching[/"Decoupled Script Caching"/]
-    click decoupledCaching "#decoupledCaching"
-    stencilNav --> stencilNavScheduling[/"Stencil Navigation Scheduling"/]
-    click stencilNavScheduling "#stencilNavScheduling"
-    stencilNavScheduling --> compressDiskCache[/"Compressed On-Disk Caching"/]
+    root --> stencilNav
+    adaptableJSLoading[/"Adaptable JS Loading"/]
+    click adaptableJSLoading "#adaptableJSLoading"
+    adaptableJSLoading --> compressDiskCache[/"Practical Compressed On-Disk Caching"/]
     click compressDiskCache "#compressDiskCache"
+    offThreadNeckoAPI --> decoupledCaching[/"Decoupled Script Caching"/]
+    click decoupledCaching "#decoupledCaching"
+    stencilNav --> decoupledCaching
     stencilNav --> unifiedSubresourceApi["Unified Subresource API"]
     click unifiedSubresourceApi "#unifiedSubresourceApi"
     offThreadNeckoAPI[/"Off-thread Necko API"/]
     click offThreadNeckoAPI "#offThreadNeckoAPI"
-    offThreadNeckoAPI --> stencilNavScheduling
+    offThreadNeckoAPI --> adaptableJSLoading
 
     root --> contextFreeParsing["JSContext Free Parsing"]
-    contextFreeParsing -.-> stencilNav
-    contextFreeParsing --> stencilNavScheduling
+    %% This is a "nice to have" dependency, but the renderer doesn't support dashed lines yet, so leave it out for now
+    %%contextFreeParsing -.-> stencilNav
+    contextFreeParsing --> adaptableJSLoading
     contextFreeParsing --> streamingParsing[/"Streaming Parsing"/]
     click streamingParsing "#streamingParsing"
     streamingParsing --> networkParsing[/"Incremental Parsing of Network Chunks"/]

--- a/tech_tree/diagram.mmd
+++ b/tech_tree/diagram.mmd
@@ -44,6 +44,10 @@ flowchart LR
     tossBytecode --> optimizedBytecode["Optimized Bytecode Emission"]
     click tossBytecode href "#tossBytecode"
 
+    progressiveStencil[/"Progressive Stencil"/]
+    click progressiveStencil "#progressiveStencil"
+    nonGCScopes --> progressiveStencil
+
     root --> immutableFlag["Immutable Object Detection at Parse Time"] --> optimizedImmutableLookups[/"Optimized Immutable Lookups"/]
     click immutableFlag href "#immutableFlag"
 
@@ -98,15 +102,32 @@ flowchart LR
     click inBinaryCode "#inBinaryCode"
     smRelocations -.-> inBinaryCode
 
-    root --> stencilNav[/"In-Memory Stencil Caching (stencil-nav)"/]
-    stencilNav --> onDiskStencil[/"On-Disk Stencil Caches"/]
+
+    stencilNav[/"In-Memory Stencil Caching (stencil-nav)"/]
+    click stencilNav "#stencilNav"
+    stencilNav --> decoupledCaching[/"Decoupled Script Caching"/]
+    click decoupledCaching "#decoupledCaching"
+    stencilNav --> stencilNavScheduling[/"Stencil Navigation Scheduling"/]
+    click stencilNavScheduling "#stencilNavScheduling"
+    stencilNavScheduling --> compressDiskCache[/"Compressed On-Disk Caching"/]
+    click compressDiskCache "#compressDiskCache"
+    stencilNav --> unifiedSubresourceApi["Unified Subresource API"]
+    click unifiedSubresourceApi "#unifiedSubresourceApi"
+    offThreadNeckoAPI[/"Off-thread Necko API"/]
+    click offThreadNeckoAPI "#offThreadNeckoAPI"
+    offThreadNeckoAPI --> stencilNavScheduling
+
     root --> contextFreeParsing["JSContext Free Parsing"]
-    stencilNav --> contextFreeParsing
+    contextFreeParsing -.-> stencilNav
+    contextFreeParsing --> stencilNavScheduling
     contextFreeParsing --> streamingParsing[/"Streaming Parsing"/]
     click streamingParsing "#streamingParsing"
-
     streamingParsing --> networkParsing[/"Incremental Parsing of Network Chunks"/]
 
+    onDiskBaselineCode[/"On-Disk Baseline Code"/]
+    click onDiskBaselineCode "#onDiskBaselineCode"
+    stencilNav --> onDiskBaselineCode
+    inBinarySelfHostedBaseline --> onDiskBaselineCode
 
 
     %% subgraph improvedBytecode [Bytecode Improvements]

--- a/tech_tree/tech_tree_style.css
+++ b/tech_tree/tech_tree_style.css
@@ -42,9 +42,18 @@ emph {
  *
  * The produced CSS classes are easy enough: LS-<startNode>.LE-<endNode>
  */
+.path.flowchart-link.LS-scheduling.LE-offThreadDelazification {
+    stroke-dasharray: 4;
+}
+.path.flowchart-link.LS-smRelocations.LE-inBinaryCode {
+    stroke-dasharray: 4;
+}
+.path.flowchart-link.LS-contextFreeParsing.LE-stencilNav {
+    stroke-dasharray: 4;
+}
 .path.flowchart-link.LS-generatorBytecodeTransforms.LE-resumeInWarp {
     stroke-dasharray: 4;
 }
-.path.flowchart-link.LS-smRelocations.LE-inBinaryStubs {
+.path.flowchart-link.LS-shareBaselineICs.LE-inBinaryStubs {
     stroke-dasharray: 4;
 }


### PR DESCRIPTION
I primarily added nodes under the `JSContext Free Parsing` subtree for the Caching project, but also "On-Disk Baseline Code" and "Progressive Stencil" (suggestions from @moztcampbell ).

I'd like opinions on whether we are missing any ideas under the `JSContext Free Parsing` subtree, if the descriptions of the nodes isn't clear, or if we need to break the nodes up into smaller chunks (or group them into larger chunks).