### PR TITLE
Replace Twitter with Mastodon in 'Where to find us' section

### DIFF
--- a/_home/find_us.markdown
+++ b/_home/find_us.markdown
@@ -5,4 +5,4 @@ order: 6
 
 * Matrix chat: [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org)
 * Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
-* Twitter: [spidermonkeyjs](https://www.twitter.com/spidermonkeyjs)
+* Mastodon: [SpiderMonkey@mozilla.social](https://mozilla.social/@SpiderMonkey)


### PR DESCRIPTION
We still have a Twitter account but we haven't posted there recently.