### PR TITLE
Add component-experts table (fixes #171)

### DIFF
--- a/_home/find_us.markdown
+++ b/_home/find_us.markdown
@@ -6,3 +6,5 @@ order: 6
 * Matrix chat: [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org)
 * Discourse: [SpiderMonkey](https://discourse.mozilla.org/c/spidermonkey)
 * Mastodon: [SpiderMonkey@mozilla.social](https://mozilla.social/@SpiderMonkey)
+
+While we strongly recommend using Matrix chat if you have questions, we also maintain [a non-exhaustive list of people who have volunteered their expertise on specific components of SpiderMonkey]({% link component-experts.md %}). For example, you might need to know who to needinfo about IonMonkey in Bugzilla...

--- a/component-experts.md
+++ b/component-experts.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Component Experts
+permalink: /component-experts/
+---
+
+# Component Experts
+
+This is a non-exhaustive list of people involved in SpiderMonkey who have volunteered their expertise on specific components of the project. We strongly recommend using [#spidermonkey:mozilla.org](https://chat.mozilla.org/#/room/#spidermonkey:mozilla.org) if you have questions, but if you need a point of contact (such as someone to needinfo in Bugzilla), then you can find them here.
+
+| Component | Short Description | Point of Contact |
+| --- | --- | --- |
+| ctypes |
+| Debugger API | API for the JS Debugger | [Bryan Thrall](https://matrix.to/#/@bthrall:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=bthrall%40mozilla.com)) |
+| JavaScript specification and language | ECMAScript and TC39 dealings | [Matt Gaudet](https://matrix.to/#/@bthrall:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=mgaudet%40mozilla.com))
+| Frontend | Parser, Stencil, and Bytecode generation | [Matt Gaudet](https://matrix.to/#/@bthrall:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=mgaudet%40mozilla.com))
+| GC | Rooting & Marking & Sweeping | [Steve Fink](https://matrix.to/#/@sfink:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=sphink%40gmail.com))
+| JS JIT Compilers | Warp and Ion, the optimizing Just-In-Time Compilers | [Iain Ireland](https://matrix.to/#/@iain:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=iireland%40mozilla.com)), [Jan de Mooij](https://matrix.to/#/@jandem:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=jdemooij%40mozilla.com))
+| Internationalization support | Internationalization support, Ecma 402 |
+| Promises |
+| Proxies, Wrappers | CCW, ES proxies | [Jan de Mooij](https://matrix.to/#/@jandem:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=jdemooij%40mozilla.com)) |
+| Regular Expression Engine | Our import of V8's RegExp JIT | [Iain Ireland](https://matrix.to/#/@iain:mozilla.org) ([bugzilla](https://bugzilla.mozilla.org/user_profile?login=iireland%40mozilla.com)) |
+| Test suites |
+| WebAssembly |
+| WebIDL |


### PR DESCRIPTION
Is the list of components complete? Should we remove any?

Feel free to add any volunteer names.