### PR TITLE
Lock FFI gem to <1.170

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,6 @@ end
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
 gem "webrick", "~> 1.7"
+
+# https://github.com/ffi/ffi/issues/1103
+gem "ffi", "< 1.17.0"


### PR DESCRIPTION
GitHub pages seems to build with Ruby 2.7.1, which seems to be incompatible with newer versions of the ffi gem.

Fixes #176