### PR TITLE
Fix spacing of hr's under headings

### DIFF
--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -56,8 +56,8 @@ a {
   }
 }
 
-.post-header {
-  hr {
+h1, h2, h3 {
+  + hr {
     margin-top: -21px;
   }
 }


### PR DESCRIPTION
Screwed this up slightly. It's supposed to look like this:

![image](https://github.com/user-attachments/assets/889e69dd-d8ab-43ed-b90f-9ff9a0bd44fc)

But it looks like this:

![image](https://github.com/user-attachments/assets/860a105c-7733-44c2-937c-cf2e8fe5e023)
