### PR TITLE
Display mouse pointer on color change and reset

### DIFF
--- a/_sass/_page-footer.scss
+++ b/_sass/_page-footer.scss
@@ -70,6 +70,11 @@ footer {
       line-height: $footer-line-height;
     }
   }
+
+  .color-toggle,
+  .color-clear {
+    cursor: pointer;
+  }
 }
 
 @media (min-width: $bp-large-tablet) {


### PR DESCRIPTION
The two actions in the footer, Change Color 🐣 and Reset Color 🥚, currently display a caret as the mouse cursor on hover. This PR changes it to a pointer to communicate they are an action.
